### PR TITLE
fix: add --cursor-blink flag to disable terminal cursor blink

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,14 +12,15 @@ import (
 
 // Config holds CLI flag values to pre-fill the TUI form.
 type Config struct {
-	From           string
-	To             string
-	Date           string
-	Time           string
-	IsArrivalTime  bool
-	NerdFont       bool
-	Theme          Theme
-	CurrentVersion string
+	From               string
+	To                 string
+	Date               string
+	Time               string
+	IsArrivalTime      bool
+	NerdFont           bool
+	DisableCursorBlink bool
+	Theme              Theme
+	CurrentVersion     string
 }
 
 // UIConfig groups all UI-related settings.

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	timeStr := flag.String("time", "", "Pre-fill time [HH:MM]")
 	arrival := flag.Bool("arrival", false, "Set date/time as arrival instead of departure time")
 	flag.Bool("nerdfont", true, "Use Nerd Font icons")
+	cursorBlink := flag.Bool("cursor-blink", true, "Enable terminal cursor blink")
 	showVersion := flag.BoolP("version", "v", false, "Print version and exit")
 
 	// --help
@@ -73,6 +74,8 @@ func main() {
 		nf, _ := flag.CommandLine.GetBool("nerdfont")
 		cfg.NerdFont = nf
 	}
+
+	cfg.DisableCursorBlink = !*cursorBlink
 
 	m := ui.NewModel(cfg)
 

--- a/ui/model.go
+++ b/ui/model.go
@@ -65,8 +65,9 @@ type appModel struct {
 	inputs         []textinput.Model
 	icons          iconSet
 	styles         styles
-	nerdFont       bool
-	isArrivalTime  bool
+	nerdFont           bool
+	isArrivalTime      bool
+	disableCursorBlink bool
 	connections    []model.Connection
 	loading        bool
 	errorMsg       error
@@ -94,7 +95,8 @@ func NewModel(cfg config.Config) appModel {
 		icons:          newIconSet(cfg.NerdFont),
 		styles:         newStyles(cfg.Theme),
 		nerdFont:       cfg.NerdFont,
-		isArrivalTime:  cfg.IsArrivalTime,
+		isArrivalTime:     cfg.IsArrivalTime,
+		disableCursorBlink: cfg.DisableCursorBlink,
 		currentVersion: cfg.CurrentVersion,
 	}
 
@@ -152,6 +154,9 @@ func NewModel(cfg config.Config) appModel {
 
 // Init implements tea.Model.
 func (m appModel) Init() tea.Cmd {
+	if m.disableCursorBlink {
+		return checkVersionCmd(m.currentVersion)
+	}
 	return tea.Batch(textinput.Blink, checkVersionCmd(m.currentVersion))
 }
 


### PR DESCRIPTION
On macOS Kitty the blinking cursor triggers constant redraws (~500ms), making text selection and link hover nearly impossible.

This adds a `--cursor-blink` flag (default: true) so affected users can disable blinking with:
```bash
sbb-tui --cursor-blink=false
```

Fixes #27