### PR TITLE
feat(ui): add scroll indicators to detail view

### DIFF
--- a/ui/connection.go
+++ b/ui/connection.go
@@ -109,13 +109,40 @@ func (m appModel) renderFullConnection(c model.Connection, width int) string {
 	wrapped := m.styles.text.Width(innerWidth).Render(content)
 	visLines := strings.Split(wrapped, "\n")
 
+	maxScroll := maxDetailScrollFromLines(visLines, boxHeight)
+
 	// Scroll and clamp to the visible area.
+	scrollY := m.detailScrollY
 	if len(visLines) > boxHeight {
-		scrollY := min(m.detailScrollY, len(visLines)-boxHeight)
+		scrollY = min(scrollY, len(visLines)-boxHeight)
 		visLines = visLines[scrollY : scrollY+boxHeight]
 	}
 
+	// Add scroll indicators when content is scrollable and at scroll limits.
+	if maxScroll > 0 {
+		innerWidth := max(width-borderSize-(detailPaddingH*2), 0)
+		// Up arrow at top-right when scrolled down.
+		if scrollY > 0 {
+			upArrow := m.styles.text.Render(m.icons.arrowUp)
+			visLines[0] = strings.Repeat(" ", max(innerWidth-lipgloss.Width(upArrow), 0)) + upArrow
+		}
+		// Down arrow at bottom-left when not at bottom.
+		if scrollY < maxScroll {
+			downArrow := m.styles.text.Render(m.icons.arrowDown)
+			lastIdx := len(visLines) - 1
+			visLines[lastIdx] = downArrow + strings.Repeat(" ", max(innerWidth-lipgloss.Width(downArrow), 0))
+		}
+	}
+
 	return m.styles.detailedResult.Width(width).Height(boxHeight).Render(strings.Join(visLines, "\n"))
+}
+
+// maxDetailScrollFromLines computes max scroll from already-wrapped visual lines.
+func maxDetailScrollFromLines(visLines []string, boxHeight int) int {
+	if len(visLines) <= boxHeight {
+		return 0
+	}
+	return len(visLines) - boxHeight
 }
 
 func (m appModel) renderJourneySection(section model.Section, width, labelCol, platformCol int, isFirst, isLast bool) []string {

--- a/ui/icons.go
+++ b/ui/icons.go
@@ -25,6 +25,10 @@ type iconSet struct {
 	keyUPDW   string
 	keyRight  string
 	keyEsc    string
+
+	// Scroll indicators
+	arrowUp   string
+	arrowDown string
 }
 
 func newIconSet(nerdFont bool) iconSet {
@@ -56,6 +60,8 @@ func newIconSet(nerdFont bool) iconSet {
 		icons.vehicle = ""
 		icons.walk = ""
 		icons.prompt = " "
+		icons.arrowUp = "▲"
+		icons.arrowDown = "▼"
 	} else {
 		icons.arrival = "⤙"
 		icons.departure = "⤚"
@@ -64,6 +70,8 @@ func newIconSet(nerdFont bool) iconSet {
 		icons.vehicle = "◇"
 		icons.walk = "walk:"
 		icons.prompt = "⏵ "
+		icons.arrowUp = "▲"
+		icons.arrowDown = "▼"
 	}
 
 	return icons


### PR DESCRIPTION
## Summary

When the detail view (right panel) is scrollable, shows ▲ at top-right when scrolled down and ▼ at bottom-left when not at bottom.

## Problem

The detailedResult window is scrollable with Shift+Arrow keys (issue #31), but there is no visual indication that the content is scrollable or what scroll position the user is at.

## Solution

Add scroll position indicators:
- **▲** at top-right when scrolled down (not at top)
- **▼** at bottom-left when not at bottom

These only appear when  (i.e., when content is actually scrollable).

## Use case

Users can immediately see whether the detail view has more content above or below without having to try scrolling.

## Testing

- Built successfully with `go build`
- The icons work in both Nerd Font and Unicode fallback modes