### PR TITLE
feat: add --no-blink flag and cursorBlink config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,14 +18,16 @@ type Config struct {
 	Time           string
 	IsArrivalTime  bool
 	NerdFont       bool
+	CursorBlink    *bool
 	Theme          Theme
 	CurrentVersion string
 }
 
 // UIConfig groups all UI-related settings.
 type UIConfig struct {
-	NerdFont *bool `yaml:"nerdfont"`
-	Theme    Theme `yaml:"theme"`
+	NerdFont    *bool `yaml:"nerdfont"`
+	CursorBlink *bool `yaml:"cursorBlink"`
+	Theme       Theme `yaml:"theme"`
 }
 
 type fileConfig struct {
@@ -118,8 +120,9 @@ func loadFile() (fileConfig, error) {
 // LoadConfig reads the config file and returns a Config with defaults merged.
 func LoadConfig() (Config, error) {
 	result := Config{
-		NerdFont: true,
-		Theme:    DefaultTheme(),
+		NerdFont:    true,
+		CursorBlink: boolPtr(true),
+		Theme:       DefaultTheme(),
 	}
 
 	fc, err := loadFile()
@@ -129,6 +132,9 @@ func LoadConfig() (Config, error) {
 
 	if fc.UI.NerdFont != nil {
 		result.NerdFont = *fc.UI.NerdFont
+	}
+	if fc.UI.CursorBlink != nil {
+		result.CursorBlink = fc.UI.CursorBlink
 	}
 
 	// NOTE: update mergeTheme when adding new Theme fields.
@@ -182,3 +188,5 @@ func mergeTheme(base Theme, override Theme) Theme {
 
 	return base
 }
+
+func boolPtr(b bool) *bool { return &b }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ func main() {
 	date := flag.String("date", "", "Pre-fill date [DD.MM.YYYY]")
 	timeStr := flag.String("time", "", "Pre-fill time [HH:MM]")
 	arrival := flag.Bool("arrival", false, "Set date/time as arrival instead of departure time")
-	flag.Bool("nerdfont", true, "Use Nerd Font icons")
+	nerdFont := flag.Bool("nerdfont", true, "Use Nerd Font icons")
+	noBlink := flag.Bool("no-blink", false, "Disable cursor blinking")
 	showVersion := flag.BoolP("version", "v", false, "Print version and exit")
 
 	// --help
@@ -69,9 +70,9 @@ func main() {
 	cfg.IsArrivalTime = *arrival
 	cfg.CurrentVersion = version
 
-	if flag.CommandLine.Changed("nerdfont") {
-		nf, _ := flag.CommandLine.GetBool("nerdfont")
-		cfg.NerdFont = nf
+	cfg.NerdFont = *nerdFont
+	if *noBlink {
+		cfg.CursorBlink = boolPtr(false)
 	}
 
 	m := ui.NewModel(cfg)
@@ -81,3 +82,5 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }

--- a/ui/model.go
+++ b/ui/model.go
@@ -66,6 +66,7 @@ type appModel struct {
 	icons          iconSet
 	styles         styles
 	nerdFont       bool
+	cursorBlink    bool
 	isArrivalTime  bool
 	connections    []model.Connection
 	loading        bool
@@ -94,6 +95,7 @@ func NewModel(cfg config.Config) appModel {
 		icons:          newIconSet(cfg.NerdFont),
 		styles:         newStyles(cfg.Theme),
 		nerdFont:       cfg.NerdFont,
+		cursorBlink:    derefBool(cfg.CursorBlink, true),
 		isArrivalTime:  cfg.IsArrivalTime,
 		currentVersion: cfg.CurrentVersion,
 	}
@@ -152,7 +154,12 @@ func NewModel(cfg config.Config) appModel {
 
 // Init implements tea.Model.
 func (m appModel) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, checkVersionCmd(m.currentVersion))
+	var cmds []tea.Cmd
+	if m.cursorBlink {
+		cmds = append(cmds, textinput.Blink)
+	}
+	cmds = append(cmds, checkVersionCmd(m.currentVersion))
+	return tea.Batch(cmds...)
 }
 
 func checkVersionCmd(current string) tea.Cmd {
@@ -183,4 +190,12 @@ func capitalise(s string) string {
 		r[0] -= 'a' - 'A'
 	}
 	return string(r)
+}
+
+// derefBool safely dereferences a bool pointer, returning default if nil.
+func derefBool(b *bool, def bool) bool {
+	if b == nil {
+		return def
+	}
+	return *b
 }


### PR DESCRIPTION
Fixes #27 — MacOS Kitty text selection issue caused by cursor blink redraw

## Problem
On MacOS Kitty, the blinking cursor triggers a redraw roughly every 500ms, making it almost impossible to select text or hover links because the selection/underline disappears immediately.

## Solution
Add a configurable cursor blink toggle via:
- **CLI flag**: `sbb-tui --no-blink` to disable blinking at startup
- **Config file**: `ui.cursorBlink: false` in `config.yaml` for a persistent default

The fix adds `CursorBlink *bool` to `Config` and `UIConfig`, wires it through `appModel.cursorBlink`, and conditionally includes `textinput.Blink` in `Init()` only when enabled.

## Use case
MacOS Kitty users can now run `sbb-tui --no-blink` or set `cursorBlink: false` in their config to get stable text selection.