### PR TITLE
feat: add scroll ▲/▼ indicators to detail panel

### DIFF
--- a/ui/connection.go
+++ b/ui/connection.go
@@ -110,12 +110,25 @@ func (m appModel) renderFullConnection(c model.Connection, width int) string {
 	visLines := strings.Split(wrapped, "\n")
 
 	// Scroll and clamp to the visible area.
-	if len(visLines) > boxHeight {
+	isScrollable := len(visLines) > boxHeight
+	if isScrollable {
 		scrollY := min(m.detailScrollY, len(visLines)-boxHeight)
 		visLines = visLines[scrollY : scrollY+boxHeight]
 	}
 
-	return m.styles.detailedResult.Width(width).Height(boxHeight).Render(strings.Join(visLines, "\n"))
+	innerContent := strings.Join(visLines, "\n")
+
+	// Add ▲/▼ scroll indicators at top-right and bottom-left when scrollable.
+	if isScrollable {
+		upIndicator := m.styles.textMuted.Render(m.icons.scrollUp)
+		downIndicator := m.styles.textMuted.Render(m.icons.scrollDown)
+		upStr := lipgloss.Place(width, boxHeight, lipgloss.Right, lipgloss.Top, upIndicator)
+		downStr := lipgloss.Place(width, boxHeight, lipgloss.Left, lipgloss.Bottom, downIndicator)
+		innerContent = lipgloss.JoinVertical(lipgloss.Top, upStr, innerContent)
+		innerContent = lipgloss.JoinVertical(lipgloss.Top, innerContent, downStr)
+	}
+
+	return m.styles.detailedResult.Width(width).Height(boxHeight).Render(innerContent)
 }
 
 func (m appModel) renderJourneySection(section model.Section, width, labelCol, platformCol int, isFirst, isLast bool) []string {

--- a/ui/icons.go
+++ b/ui/icons.go
@@ -13,18 +13,20 @@ type iconSet struct {
 	prompt    string
 
 	// Mode-invariant
-	towards   string
-	filledDot string
-	hollowDot string
-	horizLine string
-	vertLine  string
-	keyTab    string
-	keyEnter  string
-	keySpace  string
-	keyUpDw   string
-	keyUPDW   string
-	keyRight  string
-	keyEsc    string
+	towards    string
+	filledDot  string
+	hollowDot  string
+	horizLine  string
+	vertLine   string
+	scrollUp   string
+	scrollDown string
+	keyTab     string
+	keyEnter   string
+	keySpace   string
+	keyUpDw    string
+	keyUPDW    string
+	keyRight   string
+	keyEsc     string
 }
 
 func newIconSet(nerdFont bool) iconSet {
@@ -34,10 +36,12 @@ func newIconSet(nerdFont bool) iconSet {
 		stop:     "Stop",
 		towards:  "→",
 
-		filledDot: "●",
-		hollowDot: "○",
-		horizLine: "─",
-		vertLine:  "│",
+		filledDot:  "●",
+		hollowDot:  "○",
+		horizLine:  "─",
+		vertLine:   "│",
+		scrollUp:   "▲",
+		scrollDown: "▼",
 
 		keyTab:   "⇥",
 		keyEnter: "↵",
@@ -56,6 +60,8 @@ func newIconSet(nerdFont bool) iconSet {
 		icons.vehicle = ""
 		icons.walk = ""
 		icons.prompt = " "
+		icons.scrollUp = "▴"
+		icons.scrollDown = "▾"
 	} else {
 		icons.arrival = "⤙"
 		icons.departure = "⤚"
@@ -64,6 +70,8 @@ func newIconSet(nerdFont bool) iconSet {
 		icons.vehicle = "◇"
 		icons.walk = "walk:"
 		icons.prompt = "⏵ "
+		icons.scrollUp = "▲"
+		icons.scrollDown = "▼"
 	}
 
 	return icons


### PR DESCRIPTION
When the connection detail panel is scrollable (more content than visible rows), adds ▲ at top-right and ▼ at bottom-left as visual cues so users know shift+↑/↓ can scroll.

Resolves #31.