### PR TITLE
[FEATURE]: Implement Via input field

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -79,10 +79,15 @@ func FetchLocations(query string) ([]string, error) {
 
 // FetchConnections returns up to `limit` connections between two stations.
 // date is expected as YYYY-MM-DD and timeStr as HH:MM.
-func FetchConnections(from, to, date, timeStr string, isArrivalTime bool, limit int) ([]model.Connection, error) {
+func FetchConnections(from, to string, via []string, date, timeStr string, isArrivalTime bool, limit int) ([]model.Connection, error) {
 	params := url.Values{}
 	params.Set("from", from)
 	params.Set("to", to)
+	for _, v := range via {
+		if v != "" {
+			params.Add("via[]", v)
+		}
+	}
 	if date != "" {
 		params.Set("date", date)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -91,7 +91,7 @@ func TestFetchConnections(t *testing.T) {
 		]}`))
 	})
 
-	conns, err := FetchConnections("Bern", "Luzern", "2026-06-15", "14:00", true, 5)
+	conns, err := FetchConnections("Bern", "Luzern", nil, "2026-06-15", "14:00", true, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestFetchConnectionsDepartureOmitsTimeType(t *testing.T) {
 		_, _ = w.Write([]byte(`{"connections": [{"from": "Bern"}]}`))
 	})
 
-	if _, err := FetchConnections("Bern", "Luzern", "", "", false, 3); err != nil {
+	if _, err := FetchConnections("Bern", "Luzern", nil, "", "", false, 3); err != nil {
 		t.Fatal(err)
 	}
 
@@ -141,7 +141,7 @@ func TestFetchConnectionsAPIMessage(t *testing.T) {
 		_, _ = w.Write([]byte(`{"messages": ["Stop xyz not found."], "request": null, "eof": 1}`))
 	})
 
-	_, err := FetchConnections("xyz", "Bern", "", "", false, 3)
+	_, err := FetchConnections("xyz", "Bern", nil, "", "", false, 3)
 	if err == nil {
 		t.Fatal("expected error from API message")
 	}
@@ -155,7 +155,7 @@ func TestFetchConnectionsHTTPError(t *testing.T) {
 		w.WriteHeader(http.StatusTooManyRequests)
 	})
 
-	if _, err := FetchConnections("Bern", "Luzern", "", "", false, 3); err == nil {
+	if _, err := FetchConnections("Bern", "Luzern", nil, "", "", false, 4); err == nil {
 		t.Fatal("expected error on HTTP 429")
 	}
 }
@@ -165,7 +165,7 @@ func TestFetchConnectionsEmptyResult(t *testing.T) {
 		_, _ = w.Write([]byte(`{"connections": []}`))
 	})
 
-	conns, err := FetchConnections("Bern", "Luzern", "", "", false, 3)
+	conns, err := FetchConnections("Bern", "Luzern", nil, "", "", false, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 type Config struct {
 	From           string
 	To             string
+	Via            []string
 	Date           string
 	Time           string
 	IsArrivalTime  bool

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var version = "dev"
 func main() {
 	from := flag.String("from", "", "Pre-fill departure station")
 	to := flag.String("to", "", "Pre-fill arrival station")
+	via := flag.StringArray("via", nil, "Pre-fill via station(s) [repeat flag for multiple]")
 	date := flag.String("date", "", "Pre-fill date [DD.MM.YYYY]")
 	timeStr := flag.String("time", "", "Pre-fill time [HH:MM]")
 	arrival := flag.Bool("arrival", false, "Set date/time as arrival instead of departure time")
@@ -53,6 +54,7 @@ func main() {
 	// CLI flag values override config file values.
 	cfg.From = *from
 	cfg.To = *to
+	cfg.Via = *via
 	if *date != "" {
 		if _, err := time.Parse("02.01.2006", *date); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/ui/update.go
+++ b/ui/update.go
@@ -494,6 +494,7 @@ func (m appModel) searchCmd() tea.Cmd {
 		res, err := api.FetchConnections(
 			m.inputs[0].Value(),
 			m.inputs[1].Value(),
+			nil,
 			toAPIDate(completeDate(m.inputs[2].Value())),
 			completeTime(m.inputs[3].Value()),
 			m.isArrivalTime,


### PR DESCRIPTION
Resolves #29 

# Changelog

[adca37e](https://github.com/Necrom4/sbb-tui/pull/64/changes/adca37e6ed6eaab926e8c37f2aaaaf8d011d9b97): feat(config): add via station parameter to config, CLI, and API client

Adds support for the `via` parameter from the `transport.opendata.ch` API, allowing users to specify intermediate stations when searching connections.

- config/config.go: add Via []string field
- main.go: add --via CLI flag (repeatable)
- api/client.go: add via []string to FetchConnections, appends via[] params to the request URL if exists
- ui/update.go: pass nil via from existing searchCmd call